### PR TITLE
Allow noninteractive icon

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,8 +17,7 @@ $ mktrayicon -i <ICON> -t <TOOLTIP> <FIFO> &
   or
 $ mktrayicon -i <ICON> &
   or
-$ mktrayicon -i <ICON> -t &
-
+$ mktrayicon -i <ICON> -t <TOOLTIP> &
 ```
 
 If a FIFO is not provided, mktrayicon will run until killed (e.g., `pkill -f 

--- a/README.md
+++ b/README.md
@@ -6,21 +6,6 @@ tray icons without having to deal with a graphical toolkit like GTK.
 `mktrayicon` can be used two ways: To create an icon that is controlled by a 
 named pipe or, more simply, to create a non-interactive icon.
 
-Calls to mktrayicon are flexible. All of these work:
-
-```
-$ mktrayicon -p <FIFO> &
-  or
-$ mktrayicon -i <ICON> -p <FIFO> &
-  or
-$ mktrayicon -i <ICON> -t <TOOLTIP> -p <FIFO> &
-  or
-$ mktrayicon -i <ICON> &
-  or
-$ mktrayicon -i <ICON> -t <TOOLTIP> &
-  etc.
-```
-
 If a FIFO is not provided, mktrayicon will run until killed (e.g., `pkill -f 
 'mktrayicon.*<ICON>'`). If you are using a named pipe (FIFO) to control the 
 icon, *the the pipe should already be created before you call `mktrayicon`*. 
@@ -63,7 +48,7 @@ This example is also in `examples/test.sh` so you can try running it.
 
 # Set up tray icon
 mkfifo /tmp/$$.icon
-./mktrayicon -p /tmp/$$.icon &
+./mktrayicon /tmp/$$.icon &
 
 # Manipulate tray icon
 

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ mktrayicon -i <ICON> -t <TOOLTIP> &
 ```
 
 If you are using a named pipe (FIFO) to control the icon, *the the pipe should 
-already be created before you call `mktrayicon`*. If you created a non-interactive icon and later want the icon to go away, you can use a command such as `pkill 'mktrayicon.*<ICON>'`.
+already be created before you call `mktrayicon`*. If you created a non-interactive icon and later want the icon to go away, you can use a command such as `pkill -f 'mktrayicon.*<ICON>'`.
 
 Every line written to the pipe should contain a single letter specifying what
 operation to perform, optionally followed by a space and a parameter to the

--- a/README.md
+++ b/README.md
@@ -3,9 +3,21 @@
 `mktrayicon` is a simple proxy program that lets you create and modify system
 tray icons without having to deal with a graphical toolkit like GTK.
 
-`mktrayicon` expects to be given a name pipe (FIFO) file path when it is
-started, and you control your status icon by writing to this named pipe. *Note
-that the pipe should already be created before you call `mktrayicon`*.
+`mktrayicon` can be used two ways: To create an icon that is controlled by a named pipe
+or, more simply, to create a non-interactive icon using the given tooltip (use an empty
+string if you don't want a tooltip).
+
+In all, there are three ways of calling mktrayicon:
+```
+$ mktrayicon <FIFO> &
+  or
+$ mktrayicon -i <ICON> <FIFO> &
+  or
+$ mktrayicon -i <ICON> -t <TOOLTIP> &
+```
+
+If you are using a named pipe (FIFO) to control the icon, *the the pipe should 
+already be created before you call `mktrayicon`*.
 
 Every line written to the pipe should contain a single letter specifying what
 operation to perform, optionally followed by a space and a parameter to the
@@ -24,7 +36,7 @@ are supported:
 By default, the `none` tooltip icon is used. To change this, pass `-i
 <stock_icon_name>` or `-i <path_to_custom_icon>` when running `mktrayicon`.
 
-Note that any script communicating with `mktrayicon` **must**, for the time
+Note that any script communicating with `mktrayicon` via the pipe **must**, for the time
 being, send `q` when they are done. Just removing the FIFO file will **not**
 cause the tray icon to be removed.
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ $ mktrayicon -i <ICON> -t <TOOLTIP> &
 ```
 
 If you are using a named pipe (FIFO) to control the icon, *the the pipe should 
-already be created before you call `mktrayicon`*. If you created a non-interactive icon and later want the icon to go away, you can use a command such as `pkill -f 'mktrayicon.*<ICON>'`.
+already be created before you call `mktrayicon`*. If you create a non-interactive icon and later want the icon to go away, you can get rid of the icon using a command such as `pkill -f 'mktrayicon.*<ICON>'`.
 
 Every line written to the pipe should contain a single letter specifying what
 operation to perform, optionally followed by a space and a parameter to the

--- a/README.md
+++ b/README.md
@@ -6,6 +6,21 @@ tray icons without having to deal with a graphical toolkit like GTK.
 `mktrayicon` can be used two ways: To create an icon that is controlled by a 
 named pipe or, more simply, to create a non-interactive icon.
 
+Calls to mktrayicon are flexible. All of these work:
+
+```
+$ mktrayicon -p <FIFO> &
+  or
+$ mktrayicon -i <ICON> -p <FIFO> &
+  or
+$ mktrayicon -i <ICON> -t <TOOLTIP> -p <FIFO> &
+  or
+$ mktrayicon -i <ICON> &
+  or
+$ mktrayicon -i <ICON> -t <TOOLTIP> &
+  etc.
+```
+
 If a FIFO is not provided, mktrayicon will run until killed (e.g., `pkill -f 
 'mktrayicon.*<ICON>'`). If you are using a named pipe (FIFO) to control the 
 icon, *the the pipe should already be created before you call `mktrayicon`*. 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,7 @@
 tray icons without having to deal with a graphical toolkit like GTK.
 
 `mktrayicon` can be used two ways: To create an icon that is controlled by a named pipe
-or, more simply, to create a non-interactive icon using the given tooltip (use an empty
-string if you don't want a tooltip).
+or, more simply, to create a non-interactive icon using the specified tooltip string (which can be an empty string). 
 
 In all, there are three ways of calling mktrayicon:
 ```

--- a/README.md
+++ b/README.md
@@ -7,19 +7,23 @@ tray icons without having to deal with a graphical toolkit like GTK.
 named pipe or, more simply, to create a non-interactive icon using the specified 
 tooltip string (which can be an empty string if you don't need a tooltip). 
 
-In all, there are three ways of calling mktrayicon:
+Calls to mktrayicon are flexible. All of these work:
 ```
 $ mktrayicon <FIFO> &
   or
 $ mktrayicon -i <ICON> <FIFO> &
   or
-$ mktrayicon -i <ICON> -t <TOOLTIP> &
+$ mktrayicon -i <ICON> -t <TOOLTIP> <FIFO> &
+  or
+$ mktrayicon -i <ICON> &
+  or
+$ mktrayicon -i <ICON> -t &
+
 ```
 
-If you are using a named pipe (FIFO) to control the icon, *the the pipe should 
-already be created before you call `mktrayicon`*. If you create a non-
-interactive icon and later want the icon to go away, you can get rid of the icon
-using a command such as `pkill -f 'mktrayicon.*<ICON>'`.
+If a FIFO is not provided, mktrayicon will run until killed (e.g., `pkill -f 
+'mktrayicon.*<ICON>'`). If you are using a named pipe (FIFO) to control the 
+icon, *the the pipe should already be created before you call `mktrayicon`*. 
 
 Every line written to the pipe should contain a single letter specifying what
 operation to perform, optionally followed by a space and a parameter to the

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ named pipe or, more simply, to create a non-interactive icon.
 
 If a FIFO is not provided, mktrayicon will run until killed (e.g., `pkill -f 
 'mktrayicon.*<ICON>'`). If you are using a named pipe (FIFO) to control the 
-icon, *the pipe should already be created before you call `mktrayicon` and 
-it should be the last argument*. 
+icon, *the pipe should already be created before you call `mktrayicon`*. 
 
 Every line written to the pipe should contain a single letter specifying what
 operation to perform, optionally followed by a space and a parameter to the

--- a/README.md
+++ b/README.md
@@ -3,8 +3,9 @@
 `mktrayicon` is a simple proxy program that lets you create and modify system
 tray icons without having to deal with a graphical toolkit like GTK.
 
-`mktrayicon` can be used two ways: To create an icon that is controlled by a named pipe
-or, more simply, to create a non-interactive icon using the specified tooltip string (which can be an empty string if you don't need a tooltip). 
+`mktrayicon` can be used two ways: To create an icon that is controlled by a 
+named pipe or, more simply, to create a non-interactive icon using the specified 
+tooltip string (which can be an empty string if you don't need a tooltip). 
 
 In all, there are three ways of calling mktrayicon:
 ```
@@ -16,7 +17,9 @@ $ mktrayicon -i <ICON> -t <TOOLTIP> &
 ```
 
 If you are using a named pipe (FIFO) to control the icon, *the the pipe should 
-already be created before you call `mktrayicon`*. If you create a non-interactive icon and later want the icon to go away, you can get rid of the icon using a command such as `pkill -f 'mktrayicon.*<ICON>'`.
+already be created before you call `mktrayicon`*. If you create a non-
+interactive icon and later want the icon to go away, you can get rid of the icon
+using a command such as `pkill -f 'mktrayicon.*<ICON>'`.
 
 Every line written to the pipe should contain a single letter specifying what
 operation to perform, optionally followed by a space and a parameter to the
@@ -24,10 +27,12 @@ command. Each command should be terminated by a newline. The following commands
 are supported:
 
   - `q`: Terminate `mktrayicon` and remove the tray icon
-  - `i <icon>`: Set the graphic to use for the tray icon; it can be a stock icon name (see `/usr/share/icons`) or path to a custom icon
+  - `i <icon>`: Set the graphic to use for the tray icon; it can be a stock icon
+		name (see `/usr/share/icons`) or path to a custom icon
   - `t <text>`: Set the text to display in the icon tooltip
   - `t`: Remove the icon tooltip
-  - `c <cmnd>`: Set the command to be execute when the user clicks the icon (`cmnd` is passed to `/bin/sh -c`)
+  - `c <cmnd>`: Set the command to be execute when the user clicks the icon 
+		(`cmnd` is passed to `/bin/sh -c`)
   - `c`: Remove the click handler
   - `h`: Hide the tray icon
   - `s`: Show the tray icon
@@ -35,9 +40,9 @@ are supported:
 By default, the `none` tooltip icon is used. To change this, pass `-i
 <stock_icon_name>` or `-i <path_to_custom_icon>` when running `mktrayicon`.
 
-Note that any script communicating with `mktrayicon` via the pipe **must**, for the time
-being, send `q` when they are done. Just removing the FIFO file will **not**
-cause the tray icon to be removed.
+Note that any script communicating with `mktrayicon` via the pipe **must**, for 
+the time being, send `q` when they are done. Just removing the FIFO file will 
+**not** cause the tray icon to be removed.
 
 ## Why?
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ named pipe or, more simply, to create a non-interactive icon.
 
 If a FIFO is not provided, mktrayicon will run until killed (e.g., `pkill -f 
 'mktrayicon.*<ICON>'`). If you are using a named pipe (FIFO) to control the 
-icon, *the pipe should already be created before you call `mktrayicon`*. 
+icon, *the pipe should already be created before you call `mktrayicon` and
+should be the last argument provided*. 
 
 Every line written to the pipe should contain a single letter specifying what
 operation to perform, optionally followed by a space and a parameter to the

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ $ mktrayicon -i <ICON> -t <TOOLTIP> &
 ```
 
 If you are using a named pipe (FIFO) to control the icon, *the the pipe should 
-already be created before you call `mktrayicon`*.
+already be created before you call `mktrayicon`*. If you created a non-interactive icon and later want the icon to go away, you can use a command such as `pkill 'mktrayicon.*<ICON>'`.
 
 Every line written to the pipe should contain a single letter specifying what
 operation to perform, optionally followed by a space and a parameter to the

--- a/README.md
+++ b/README.md
@@ -4,21 +4,7 @@
 tray icons without having to deal with a graphical toolkit like GTK.
 
 `mktrayicon` can be used two ways: To create an icon that is controlled by a 
-named pipe or, more simply, to create a non-interactive icon using the specified 
-tooltip string (which can be an empty string if you don't need a tooltip). 
-
-Calls to mktrayicon are flexible. All of these work:
-```
-$ mktrayicon <FIFO> &
-  or
-$ mktrayicon -i <ICON> <FIFO> &
-  or
-$ mktrayicon -i <ICON> -t <TOOLTIP> <FIFO> &
-  or
-$ mktrayicon -i <ICON> &
-  or
-$ mktrayicon -i <ICON> -t <TOOLTIP> &
-```
+named pipe or, more simply, to create a non-interactive icon.
 
 If a FIFO is not provided, mktrayicon will run until killed (e.g., `pkill -f 
 'mktrayicon.*<ICON>'`). If you are using a named pipe (FIFO) to control the 
@@ -62,7 +48,7 @@ This example is also in `examples/test.sh` so you can try running it.
 
 # Set up tray icon
 mkfifo /tmp/$$.icon
-./mktrayicon /tmp/$$.icon &
+./mktrayicon -p /tmp/$$.icon &
 
 # Manipulate tray icon
 

--- a/README.md
+++ b/README.md
@@ -8,8 +8,7 @@ named pipe or, more simply, to create a non-interactive icon.
 
 If a FIFO is not provided, mktrayicon will run until killed (e.g., `pkill -f 
 'mktrayicon.*<ICON>'`). If you are using a named pipe (FIFO) to control the 
-icon, *the pipe should already be created before you call `mktrayicon` and
-should be the last argument provided*. 
+icon, *the pipe should already be created before you call `mktrayicon`*. 
 
 Every line written to the pipe should contain a single letter specifying what
 operation to perform, optionally followed by a space and a parameter to the

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ named pipe or, more simply, to create a non-interactive icon.
 
 If a FIFO is not provided, mktrayicon will run until killed (e.g., `pkill -f 
 'mktrayicon.*<ICON>'`). If you are using a named pipe (FIFO) to control the 
-icon, *the the pipe should already be created before you call `mktrayicon`*. 
+icon, *the pipe should already be created before you call `mktrayicon` and 
+it should be the last argument*. 
 
 Every line written to the pipe should contain a single letter specifying what
 operation to perform, optionally followed by a space and a parameter to the

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 tray icons without having to deal with a graphical toolkit like GTK.
 
 `mktrayicon` can be used two ways: To create an icon that is controlled by a named pipe
-or, more simply, to create a non-interactive icon using the specified tooltip string (which can be an empty string). 
+or, more simply, to create a non-interactive icon using the specified tooltip string (which can be an empty string if you don't need a tooltip). 
 
 In all, there are three ways of calling mktrayicon:
 ```

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -226,7 +226,6 @@ int main(int argc, char **argv)
 		printf("  -i ICON\tUse the specified ICON when initializing\n");
 		printf("  -t TOOLTIP\tUse the specified TOOLTIP when initializing\n");
 		printf("\n");
-		printf("If a FIFO is provided, it should be the last argument\n");
 		printf("If a FIFO is not provided, mktrayicon will run until killed\n");
 		printf("Report bugs at https://github.com/jonhoo/mktrayicon\n");
 		return 0;
@@ -253,8 +252,8 @@ int main(int argc, char **argv)
 		gtk_status_icon_set_tooltip_text(icon, tooltip);
 	}
 
-	if (optind < argc) {
-		pipe = argv[argc - 1];
+	if (optind < argc) { /* if all arguments were option arguments, optind will be equal to argc */
+		pipe = argv[optind]; /* otherwise, optind is the index of the first non-option argument */
 		reader = g_thread_new("watch_fifo", watch_fifo, pipe);
 	}
 

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -220,7 +220,7 @@ int main(int argc, char **argv)
 	gtk_init(&argc, &argv);
 
 	if (argc == 1) {
-		printf("Usage: %s [-i ICON] [-t TOOLTIP] [-p FIFO]\n", *argv);
+		printf("Usage: %s [-i ICON] [-t TOOLTIP] [FIFO]\n", *argv);
 		printf("Create a system tray icon as specified\n");
 		printf("\n");
 		printf("  -i ICON\tUse the specified ICON when initializing\n");
@@ -232,7 +232,7 @@ int main(int argc, char **argv)
 	}
 
 	int c;
-	while ((c = getopt (argc, argv, "i:t:p:")) != -1)
+	while ((c = getopt (argc, argv, "i:t:")) != -1)
  		switch (c)
 		{
 			case 'i':
@@ -241,13 +241,14 @@ int main(int argc, char **argv)
 			case 't':
 				tooltip = optarg;
 				break;
-			case 'p':
-				pipe = optarg;
-				break;
 			case '?':
 				fprintf(stderr, "Unknown option: %c\n", optopt);
 				return 1;
 		}
+
+	int index;
+  	for (index = optind; index < argc; index++)
+		pipe = argv[index];
 
 	icon = create_tray_icon(start_icon);
 

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -222,6 +222,7 @@ int main(int argc, char **argv)
 		printf("\n");
 		printf("  -i ICON\tUse the specified ICON when initializing\n");
 		printf("  -t TOOLTIP\tUse the specified TOOLTIP when initializing\n");
+		printf("  if a FIFO is not provided, mktrayicon will run until killed\n");
 		printf("\n");
 		printf("Report bugs at https://github.com/jonhoo/mktrayicon\n");
 		return 0;
@@ -237,9 +238,13 @@ int main(int argc, char **argv)
 		gtk_status_icon_set_tooltip_text(icon, argv[4]);
 	}
 
-	if (/* test to see if last arg is a pipe */) {
+	/* test if last argument is a pipe */
+	char *command = malloc(1024*sizeof(char));
+	sprintf(command, "test -p %s", argv[argc-1]);
+	if (system(command) == 0) { /* last argument is a pipe */
 		reader = g_thread_new("watch_fifo", watch_fifo, argv[argc-1]);
 	}
+	free(command);
 
 	gtk_main();
 	return 0;

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -251,9 +251,11 @@ int main(int argc, char **argv)
 	if (tooltip) {
 		gtk_status_icon_set_tooltip_text(icon, tooltip);
 	}
-
-	if (optind < argc) { /* if all arguments were option arguments, optind will be equal to argc */
-		pipe = argv[optind]; /* otherwise, optind is the index of the first non-option argument */
+	
+	/* getopt moves positional arguments (if there are any) to the end of the argv array */
+	/* optind holds the index of next argument to be parsed (so it will hold argc if all arguments have been parsed) */
+	if (optind < argc) {
+		pipe = argv[optind];
 		reader = g_thread_new("watch_fifo", watch_fifo, pipe);
 	}
 

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -240,7 +240,7 @@ int main(int argc, char **argv)
 
 	/* test if last argument is a pipe */
 	char *command = malloc(1024*sizeof(char));
-	sprintf(command, "test -p %s", argv[argc-1]);
+	sprintf(command, "test -p %s 2>/dev/null", argv[argc-1]);
 	if (system(command) == 0) { /* last argument is a pipe */
 		reader = g_thread_new("watch_fifo", watch_fifo, argv[argc-1]);
 	}

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -217,7 +217,7 @@ int main(int argc, char **argv)
 	gtk_init(&argc, &argv);
 
 	if (argc == 1) {
-		printf("Usage: %s [-i ICON] FIFO --or-- %s -i ICON -t TOOLTIP\n", *argv, *argv);
+		printf("Usage: %s [-i ICON] [-t TOOLTIP] [FIFO]\n", *argv);
 		printf("Create a system tray icon as specified\n");
 		printf("\n");
 		printf("  -i ICON\tUse the specified ICON when initializing\n");
@@ -233,14 +233,14 @@ int main(int argc, char **argv)
 
 	icon = create_tray_icon(start_icon);
 
-	if (strcmp(argv[3], "-t") == 0) { /* icon is non-interactive, use given tooltip */
+	if (strcmp(argv[3], "-t") == 0) {
 		gtk_status_icon_set_tooltip_text(icon, argv[4]);
 	}
-	else { /* icon is interactive, listen to the specified named pipe */
+
+	if (/* test to see if last arg is a pipe */) {
 		reader = g_thread_new("watch_fifo", watch_fifo, argv[argc-1]);
 	}
 
 	gtk_main();
 	return 0;
 }
-

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -225,31 +225,30 @@ int main(int argc, char **argv)
 		printf("\n");
 		printf("  -i ICON\tUse the specified ICON when initializing\n");
 		printf("  -t TOOLTIP\tUse the specified TOOLTIP when initializing\n");
-		printf("  if a FIFO is provided, it should be the last argument\n");
-		printf("  if a FIFO is not provided, mktrayicon will run until killed\n");
 		printf("\n");
+		printf("If a FIFO is not provided, mktrayicon will run until killed\n");
 		printf("Report bugs at https://github.com/jonhoo/mktrayicon\n");
 		return 0;
 	}
 
-	int parsed_args = 1;
 	int c;
 	while ((c = getopt (argc, argv, "i:t:")) != -1)
  		switch (c)
 		{
 			case 'i':
 				start_icon = optarg;
-				parsed_args += 2;
 				break;
 			case 't':
 				tooltip = optarg;
-				parsed_args += 2;
 				break;
 			case '?':
 				fprintf(stderr, "Unknown option: %c\n", optopt);
 				return 1;
 		}
 
+	int index;
+  	for (index = optind; index < argc; index++)
+		pipe = argv[index]; /* this assigns the non-option argument (if one exists) to pipe */
 
 	icon = create_tray_icon(start_icon);
 
@@ -257,8 +256,7 @@ int main(int argc, char **argv)
 		gtk_status_icon_set_tooltip_text(icon, tooltip);
 	}
 
-	if (parsed_args < argc) {
-		pipe = argv[argc-1];
+	if (pipe) {
 		reader = g_thread_new("watch_fifo", watch_fifo, pipe);
 	}
 

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -251,9 +251,10 @@ int main(int argc, char **argv)
 	if (tooltip) {
 		gtk_status_icon_set_tooltip_text(icon, tooltip);
 	}
-	
-	/* getopt moves positional arguments (if there are any) to the end of the argv array */
-	/* optind holds the index of next argument to be parsed (so it will be equal to argc if all arguments have been parsed) */
+
+	/* optind holds the index of the next argument to be parsed */
+	/* getopt moved positional arguments (if there were any) to the end of the argv array, without parsing them */
+	/* so if there were only non-positional arguments, all arguments have been barsed and optind will be equal to argc */
 	if (optind < argc) {
 		pipe = argv[optind];
 		reader = g_thread_new("watch_fifo", watch_fifo, pipe);

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -225,30 +225,31 @@ int main(int argc, char **argv)
 		printf("\n");
 		printf("  -i ICON\tUse the specified ICON when initializing\n");
 		printf("  -t TOOLTIP\tUse the specified TOOLTIP when initializing\n");
+		printf("  if a FIFO is provided, it should be the last argument\n");
 		printf("  if a FIFO is not provided, mktrayicon will run until killed\n");
 		printf("\n");
 		printf("Report bugs at https://github.com/jonhoo/mktrayicon\n");
 		return 0;
 	}
 
+	int parsed_args = 1;
 	int c;
 	while ((c = getopt (argc, argv, "i:t:")) != -1)
  		switch (c)
 		{
 			case 'i':
 				start_icon = optarg;
+				parsed_args += 2;
 				break;
 			case 't':
 				tooltip = optarg;
+				parsed_args += 2;
 				break;
 			case '?':
 				fprintf(stderr, "Unknown option: %c\n", optopt);
 				return 1;
 		}
 
-	int index;
-  	for (index = optind; index < argc; index++)
-		pipe = argv[index];
 
 	icon = create_tray_icon(start_icon);
 
@@ -256,7 +257,8 @@ int main(int argc, char **argv)
 		gtk_status_icon_set_tooltip_text(icon, tooltip);
 	}
 
-	if (pipe) {
+	if (parsed_args < argc) {
+		pipe = argv[argc-1];
 		reader = g_thread_new("watch_fifo", watch_fifo, pipe);
 	}
 

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -254,7 +254,7 @@ int main(int argc, char **argv)
 
 	/* optind holds the index of the next argument to be parsed */
 	/* getopt moved positional arguments (if there were any) to the end of the argv array, without parsing them */
-	/* so if there were only non-positional arguments, all arguments have been barsed and optind will be equal to argc */
+	/* so if there were only non-positional arguments, all arguments have been parsed and optind will be equal to argc */
 	if (optind < argc) {
 		pipe = argv[optind];
 		reader = g_thread_new("watch_fifo", watch_fifo, pipe);

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -226,6 +226,7 @@ int main(int argc, char **argv)
 		printf("  -i ICON\tUse the specified ICON when initializing\n");
 		printf("  -t TOOLTIP\tUse the specified TOOLTIP when initializing\n");
 		printf("\n");
+		printf("If a FIFO is provided, it should be the last argument\n");
 		printf("If a FIFO is not provided, mktrayicon will run until killed\n");
 		printf("Report bugs at https://github.com/jonhoo/mktrayicon\n");
 		return 0;
@@ -246,17 +247,14 @@ int main(int argc, char **argv)
 				return 1;
 		}
 
-	int index;
-  	for (index = optind; index < argc; index++)
-		pipe = argv[index]; /* this assigns the non-option argument (if one exists) to pipe */
-
 	icon = create_tray_icon(start_icon);
 
 	if (tooltip) {
 		gtk_status_icon_set_tooltip_text(icon, tooltip);
 	}
 
-	if (pipe) {
+	if (optind < argc) {
+		pipe = argv[argc - 1];
 		reader = g_thread_new("watch_fifo", watch_fifo, pipe);
 	}
 

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -228,23 +228,23 @@ int main(int argc, char **argv)
 		return 0;
 	}
 
+	int args = 1;
+
 	if (strcmp(argv[1], "-i") == 0) {
 		start_icon = argv[2];
+		args += 2;
 	}
 
 	icon = create_tray_icon(start_icon);
 
 	if (strcmp(argv[3], "-t") == 0) {
 		gtk_status_icon_set_tooltip_text(icon, argv[4]);
+		args += 2;
 	}
 
-	/* test if last argument is a pipe */
-	char *command = malloc(1024*sizeof(char));
-	sprintf(command, "test -p %s 2>/dev/null", argv[argc-1]);
-	if (system(command) == 0) { /* last argument is a pipe */
+	if (args < argc) { /* last argument is a pipe */
 		reader = g_thread_new("watch_fifo", watch_fifo, argv[argc-1]);
 	}
-	free(command);
 
 	gtk_main();
 	return 0;

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -235,9 +235,7 @@ int main(int argc, char **argv)
 		args += 2;
 	}
 
-	icon = create_tray_icon(start_icon);
-
-	if (strcmp(argv[3], "-t") == 0) {
+	if (argc > 3 && strcmp(argv[3], "-t") == 0) {
 		gtk_status_icon_set_tooltip_text(icon, argv[4]);
 		args += 2;
 	}
@@ -245,6 +243,8 @@ int main(int argc, char **argv)
 	if (args < argc) { /* last argument is a pipe */
 		reader = g_thread_new("watch_fifo", watch_fifo, argv[argc-1]);
 	}
+
+	icon = create_tray_icon(start_icon);
 
 	gtk_main();
 	return 0;

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -212,6 +212,7 @@ int main(int argc, char **argv)
 	char *start_icon = "none";
 	FILE *fifo;
 	GThread *reader;
+
 	XInitThreads(); /* see http://stackoverflow.com/a/18690540/472927 */
 	gtk_init(&argc, &argv);
 

--- a/mktrayicon.c
+++ b/mktrayicon.c
@@ -253,7 +253,7 @@ int main(int argc, char **argv)
 	}
 	
 	/* getopt moves positional arguments (if there are any) to the end of the argv array */
-	/* optind holds the index of next argument to be parsed (so it will hold argc if all arguments have been parsed) */
+	/* optind holds the index of next argument to be parsed (so it will be equal to argc if all arguments have been parsed) */
 	if (optind < argc) {
 		pipe = argv[optind];
 		reader = g_thread_new("watch_fifo", watch_fifo, pipe);


### PR DESCRIPTION
Jon,

Most of the time it's great to be able to control the icon with a named pipe (e.g., to monitor wifi strength or battery charge). However, sometimes I just want to create a simple, non-interactive icon to show that something is on (e.g., VPN). For these situations, it's easier to just specify the tooltip right away (one step) without having to create a pipe, call mktrayicon, then specify the tooltip via the pipe (three steps). When such an icon is no longer needed, that instance of mktrayicon can simply be killed using `pkill -f 'mktrayicon.*<icon_name>'`. There is also less overhead when the icon is no longer needed, since there is no obsolete pipe to delete.

Hopefully you agree that this is a nice feature. Here's the patch.



